### PR TITLE
Feat: Allow use of array of endpoints in yml configs

### DIFF
--- a/configs/astar.yml
+++ b/configs/astar.yml
@@ -1,4 +1,6 @@
-endpoint: wss://rpc.astar.network
+endpoint:
+  - wss://rpc.astar.network
+  - wss://astar-rpc.dwellir.com
 mock-signature-host: true
 
 import-storage:

--- a/configs/statemint.yml
+++ b/configs/statemint.yml
@@ -1,4 +1,7 @@
-endpoint: wss://statemint-rpc.dwellir.com
+endpoint:
+  - wss://polkadot-asset-hub-rpc.polkadot.io
+  - wss://statemint-rpc.dwellir.com
+  - wss://statemint-rpc-tn.dwellir.com
 mock-signature-host: true
 
 import-storage:

--- a/packages/chopsticks/src/schema/index.ts
+++ b/packages/chopsticks/src/schema/index.ts
@@ -13,11 +13,10 @@ export const genesisSchema = z.object({
 })
 
 export type Genesis = z.infer<typeof genesisSchema>
-
 export const configSchema = z
   .object({
     port: z.number().optional(),
-    endpoint: z.string().optional(),
+    endpoint: z.union([z.string(), z.array(z.string())]).optional(),
     block: z.union([z.string().length(66).startsWith('0x'), z.number(), z.null()]).optional(),
     'build-block-mode': z.nativeEnum(BuildBlockMode).optional(),
     'import-storage': z.any().optional(),


### PR DESCRIPTION
Since the generated `Config.endpoint` value is only used to instantiate `WsProvider`, the constructor of which allows a single endpoint as well as an array of endpoints as parameter, expand the `Config.endpoint` to also allow arrays of strings.